### PR TITLE
DOP-1380 - Set help content automation template

### DIFF
--- a/src/i18n/automation-dicc-en.js
+++ b/src/i18n/automation-dicc-en.js
@@ -992,7 +992,8 @@ export const automation_en_translations = {
     "description2": "Get better results and grow your business while your campaigns run automatically.",
     "help": {
       "url": "https://help.fromdoppler.com/en/how-to-use-email-automation?utm_source=direct",
-      "title": "Learn more about Automation"
+      "label": "Learn more about Automation here",
+      "title": "Do you have any doubts? "
     },
     "create_template": "Use pre-built flow",
     "board": {

--- a/src/i18n/automation-dicc-es.js
+++ b/src/i18n/automation-dicc-es.js
@@ -991,7 +991,8 @@ export const automation_es_translations = {
     "description2": "Obtén mejores resultados y haz crecer tu negocio mientras tus campañas se ejecutan automáticamente.",
     "help": {
       "url": "https://help.fromdoppler.com/es/como-utilizar-email-automation/",
-      "title": "Aprende más sobre Automation"
+      "label": "Aprende más sobre Automation",
+      "title": "¿Tienes dudas?",
     },
     "create_template": "Usar esta plantilla",
     "board": {

--- a/src/partials/automation/editor/directives/dp-editor-template-preview.html
+++ b/src/partials/automation/editor/directives/dp-editor-template-preview.html
@@ -22,8 +22,13 @@
             <li>{{ 'automationTemplates.templatePreview.template_' + idAutomationTemplateSelected + '_allow_item1' | translate }}</li>
             <li>{{ 'automationTemplates.templatePreview.template_' + idAutomationTemplateSelected + '_allow_item2' | translate }}</li>
           </ul>
-          <br>
-          <a href="{{ 'automationTemplates.help.url' | translate }}">{{ 'automationTemplates.help.title' | translate }}</a>
+          <div class="margin-t-25">
+            <div class="dp-wrap-isologo--small dp--italic">
+              <p>{{ 'automationTemplates.help.title' | translate }}
+                <a class="dp--text-underline" href="{{ 'automationTemplates.help.url' | translate }}">{{ 'automationTemplates.help.label' | translate }}</a>
+              </p>
+            </div>
+          </div>
         </div>
         <div class="col-sm-6 dp-automation-template-preview-image">
           <div class="dp-automation-template-preview-image-{{idAutomationTemplateSelected}}-{{lang}}"></div>

--- a/src/partials/automation/editor/directives/dp-editor-template.html
+++ b/src/partials/automation/editor/directives/dp-editor-template.html
@@ -15,8 +15,13 @@
           <p>{{ 'automationTemplates.description0' | translate }}</p>
           <p>{{ 'automationTemplates.description1' | translate }}</p>
           <p>{{ 'automationTemplates.description2' | translate }}</p>
-          <br>
-          <a href="{{ 'automationTemplates.help.url' | translate }}">{{ 'automationTemplates.help.title' | translate }}</a>
+          <div class="margin-t-25">
+            <div class="dp-wrap-isologo--small dp--italic">
+              <p>{{ 'automationTemplates.help.title' | translate }}
+                <a class="dp--text-underline" href="{{ 'automationTemplates.help.url' | translate }}">{{ 'automationTemplates.help.label' | translate }}</a>
+              </p>
+            </div>
+          </div>
         </div>
         <div class="col-sm-5 dp-automation-shape"></div>
       </div>


### PR DESCRIPTION
set new content for automation template


Fixes: [DOP-1380 ](https://makingsense.atlassian.net/browse/DOP-1380)

Figma: [Automation template ](https://www.figma.com/file/Z9hp6vKtizfqxRDZ8P52Cz/Automation-%7C-Templates)

![link template](https://github.com/FromDoppler/doppler-automation-editor/assets/83654756/da4708aa-8e34-4083-92b4-8fdc8a78b130)

![link template preview](https://github.com/FromDoppler/doppler-automation-editor/assets/83654756/126b109d-b72e-4a10-8256-eb075099e5b1)
