### PR TITLE
fix: set the initial condition like selected

### DIFF
--- a/src/directives/automation/editor/components/initialConditions/dpEditorDynamicContentCondition.js
+++ b/src/directives/automation/editor/components/initialConditions/dpEditorDynamicContentCondition.js
@@ -3,9 +3,9 @@
 
   angular
     .module('dopplerApp.automation.editor')
-    .directive('dpEditorDynamicContentCondition', ['automation', 'COMPONENT_TYPE', dpEditorDynamicContentCondition]);
+    .directive('dpEditorDynamicContentCondition', ['automation', 'COMPONENT_TYPE', 'selectedElementsService', dpEditorDynamicContentCondition]);
 
-  function dpEditorDynamicContentCondition(automation, COMPONENT_TYPE) {
+  function dpEditorDynamicContentCondition(automation, COMPONENT_TYPE, selectedElementsService) {
     var directive = {
       restrict: 'E',
       scope: {
@@ -52,6 +52,7 @@
           type: COMPONENT_TYPE.CAMPAIGN
         };
         automation.addComponent(campaign, scope.$parent.component.parentUid);
+        selectedElementsService.setSelectedComponent(scope.component);
       }
     }
 


### PR DESCRIPTION
The idea was to maintain the exact behavior of the old editor, when an abandoned cart was created, the [initial condition was settled like the component selected](https://github.com/MakingSense/Doppler/blob/develop/Doppler.Presentation.MVC/angularjs/directives/automation/editor/dpEditorTypes.js#L73).

related to [DOP-1389](https://makingsense.atlassian.net/browse/DOP-1389)

[DOP-1389]: https://makingsense.atlassian.net/browse/DOP-1389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ