### PR TITLE
fix: set "unsavedChanges" flag like true

### DIFF
--- a/src/directives/automation/editor/components/initialConditions/dpEditorDynamicContentCondition.js
+++ b/src/directives/automation/editor/components/initialConditions/dpEditorDynamicContentCondition.js
@@ -3,9 +3,20 @@
 
   angular
     .module('dopplerApp.automation.editor')
-    .directive('dpEditorDynamicContentCondition', ['automation', 'COMPONENT_TYPE', 'selectedElementsService', dpEditorDynamicContentCondition]);
+    .directive('dpEditorDynamicContentCondition', [
+      'automation',
+      'COMPONENT_TYPE',
+      'selectedElementsService',
+      'changesManager',
+      dpEditorDynamicContentCondition
+    ]);
 
-  function dpEditorDynamicContentCondition(automation, COMPONENT_TYPE, selectedElementsService) {
+  function dpEditorDynamicContentCondition(
+    automation,
+    COMPONENT_TYPE,
+    selectedElementsService,
+    changesManager
+  ) {
     var directive = {
       restrict: 'E',
       scope: {
@@ -52,6 +63,8 @@
           type: COMPONENT_TYPE.CAMPAIGN
         };
         automation.addComponent(campaign, scope.$parent.component.parentUid);
+        changesManager.setUnsavedChanges(true);
+
         selectedElementsService.setSelectedComponent(scope.component);
       }
     }


### PR DESCRIPTION
Set `unsavedChanges` flag to true in order to force saving the model (and the relation with `AutomationEventDynamicContent`) when the user hit "exit and edit later".

related to DOP-1389