### PR TITLE
Dop 1406 fix cart validation

### DIFF
--- a/src/directives/automation/editor/components/initialConditions/dpEditorDynamicContentCondition.js
+++ b/src/directives/automation/editor/components/initialConditions/dpEditorDynamicContentCondition.js
@@ -7,7 +7,6 @@
       'automation',
       'COMPONENT_TYPE',
       'selectedElementsService',
-      'changesManager',
       dpEditorDynamicContentCondition
     ]);
 
@@ -15,7 +14,6 @@
     automation,
     COMPONENT_TYPE,
     selectedElementsService,
-    changesManager
   ) {
     var directive = {
       restrict: 'E',
@@ -63,8 +61,11 @@
           type: COMPONENT_TYPE.CAMPAIGN
         };
         automation.addComponent(campaign, scope.$parent.component.parentUid);
-        changesManager.setUnsavedChanges(true);
+      }
 
+      // On the first time the idThirdPartyApp will be null, 
+      // so the app put focus on the initial condition in order to be changed
+      if (!scope.component.idThirdPartyApp) {
         selectedElementsService.setSelectedComponent(scope.component);
       }
     }

--- a/src/directives/automation/editor/panel/initialConditions/dpEditorPanelDynamicContentCondition.js
+++ b/src/directives/automation/editor/panel/initialConditions/dpEditorPanelDynamicContentCondition.js
@@ -34,6 +34,7 @@
       // set default idThirdPartyApp value on the first time
       if (!scope.selectedComponent.idThirdPartyApp) {
         handleThidPartyAppChange(scope.productsStoreOptions[0].value);
+        changesManager.setUnsavedChanges(true);
       }
 
       function handleThidPartyAppChange(value) {
@@ -45,15 +46,6 @@
         }
         scope.selectedComponent.setData({
           idThirdPartyApp: value,
-        });
-        automation.applyDropDownChange();
-
-        changesManager.add({
-          type: CHANGE_TYPE.PROPERTY,
-          uid: scope.selectedComponent.uid,
-          key: 'idThirdPartyApp',
-          oldValue: scope.selectedComponent.idThirdPartyApp,
-          newValue: value,
         });
       }
 
@@ -102,6 +94,17 @@
 
       scope.onProductStoreChange = function (option) {
         handleThidPartyAppChange(option.value);
+
+        automation.applyDropDownChange();
+
+        changesManager.add({
+          type: CHANGE_TYPE.PROPERTY,
+          uid: scope.selectedComponent.uid,
+          key: 'idThirdPartyApp',
+          oldValue: scope.selectedComponent.idThirdPartyApp,
+          newValue: option.value,
+        });
+
         automation.updateAutomationFlowState();
       };
 

--- a/src/directives/automation/editor/panel/initialConditions/dpEditorPanelDynamicContentCondition.js
+++ b/src/directives/automation/editor/panel/initialConditions/dpEditorPanelDynamicContentCondition.js
@@ -30,8 +30,32 @@
       scope.timeUnitOptions = optionsListDataservice.getTimeUnitOptions();
 
       scope.productsStoreOptions = automation.getProductStoresList(scope.selectedComponent.automationType);
-      scope.selectedComponent.idThirdPartyApp = scope.selectedComponent.idThirdPartyApp ||
-        scope.productsStoreOptions[0].value;
+
+      // set default idThirdPartyApp value on the first time
+      if (!scope.selectedComponent.idThirdPartyApp) {
+        handleThidPartyAppChange(scope.productsStoreOptions[0].value);
+      }
+
+      function handleThidPartyAppChange(value) {
+        if (scope.selectedComponent.automationType === AUTOMATION_TYPE.VISITED_PRODUCTS) {
+          scope.showDomainErrorMsg = automation.domainHaveErrors(scope.productsStoreOptions, value);
+        } else if (scope.selectedComponent.automationType === AUTOMATION_TYPE.ABANDONED_CART
+          && value === INTEGRATION_CODES.TIENDANUBE) {
+          scope.showDomainErrorMsg = automation.domainHaveErrors(scope.productsStoreOptions, value);
+        }
+        scope.selectedComponent.setData({
+          idThirdPartyApp: value,
+        });
+        automation.applyDropDownChange();
+
+        changesManager.add({
+          type: CHANGE_TYPE.PROPERTY,
+          uid: scope.selectedComponent.uid,
+          key: 'idThirdPartyApp',
+          oldValue: scope.selectedComponent.idThirdPartyApp,
+          newValue: value,
+        });
+      }
 
       switch (scope.selectedComponent.automationType) {
         case AUTOMATION_TYPE.VISITED_PRODUCTS:
@@ -77,25 +101,7 @@
       scope.selectedComponent.eventIntervalMinutesLabel = $translate.instant('automation_editor.sidebar.' + scope.selectedComponent.automationType + '.drop_down_time_options.option' + scope.selectedComponent.eventIntervalMinutes);
 
       scope.onProductStoreChange = function (option) {
-        if (scope.selectedComponent.automationType === AUTOMATION_TYPE.VISITED_PRODUCTS) {
-          scope.showDomainErrorMsg = automation.domainHaveErrors(scope.productsStoreOptions, option.value);
-        } else if (scope.selectedComponent.automationType === AUTOMATION_TYPE.ABANDONED_CART
-          && option.value === INTEGRATION_CODES.TIENDANUBE) {
-          scope.showDomainErrorMsg = automation.domainHaveErrors(scope.productsStoreOptions, option.value);
-        }
-        scope.selectedComponent.setData({
-          idThirdPartyApp: option.value
-        });
-        automation.applyDropDownChange();
-
-        changesManager.add({
-          type: CHANGE_TYPE.PROPERTY,
-          uid: scope.selectedComponent.uid,
-          key: 'idThirdPartyApp',
-          oldValue: scope.selectedComponent.idThirdPartyApp,
-          newValue: option.value
-        });
-
+        handleThidPartyAppChange(option.value);
         automation.updateAutomationFlowState();
       };
 


### PR DESCRIPTION
Se resolvio el problema de guardar la relacion con `AutomationEventDynamicContent` cuando se crea un automation de carrito desde template (esto provoca que la validacion de Carrito funcione como se espera).
Se unifico para que el trato sea el mismo cuando es un carrito creado desde 0, o desde template.

Ticket relacionado: [DOP-1406](https://makingsense.atlassian.net/browse/DOP-1406)

[DOP-1406]: https://makingsense.atlassian.net/browse/DOP-1406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ