### PR TITLE
DOP-1409 - Add preview controller

### DIFF
--- a/src/controllers/shared/index.js
+++ b/src/controllers/shared/index.js
@@ -1,5 +1,6 @@
 import "./footerCtrl.js";
 import "./headerCtrl.js";
+import "./previewCtrl.js";
 import "./modalConfigureDkimCtrl.js";
 import "./modalCreateDkimCtrl.js";
 import "./modalNoDynamicElementCtrl.js";


### PR DESCRIPTION
Missing preview controller

[DOP-1409](https://makingsense.atlassian.net/browse/DOP-1409)

Error:

![image](https://github.com/FromDoppler/doppler-automation-editor/assets/83654756/0f7c325b-f486-4b9b-9c18-61278a3aa0be)

Fix:

https://github.com/FromDoppler/doppler-automation-editor/assets/83654756/b32e454e-5907-4516-9895-268c49da7540






[DOP-1409]: https://makingsense.atlassian.net/browse/DOP-1409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ