### PR TITLE
DOP-1407 - resolve visual issue in smart subject button

### DIFF
--- a/src/css/app/templates/automation/_editor-panel.scss
+++ b/src/css/app/templates/automation/_editor-panel.scss
@@ -93,7 +93,6 @@
       .dp-automation-subject-panel {
         margin-top: 40px;
         .dp-show-tips {
-          text-align:right;
           font-weight: bold;
           bottom: 10px;
           &::before {


### PR DESCRIPTION
fix: add space between text and icon in the button

issue:

![image](https://github.com/FromDoppler/doppler-automation-editor/assets/83654756/10b37189-7c39-4065-99a7-a4bf974a2de6)


fix:

![image](https://github.com/FromDoppler/doppler-automation-editor/assets/83654756/5067f5af-6ccf-41c8-9706-a82226c08954)

![image](https://github.com/FromDoppler/doppler-automation-editor/assets/83654756/929aaa21-7d67-4d8b-8002-e7eb91709548)
