### PR TITLE
DOP-1427 - Set template ribbon content

### DIFF
--- a/src/i18n/automation-dicc-en.js
+++ b/src/i18n/automation-dicc-en.js
@@ -1635,5 +1635,6 @@ export const automation_en_translations = {
       "maxlength" : "Ouch! You have reached the maximum allowed length.",
       "duplicated" : "Ouch! That name already exists."
   },
-  "image_placeholder_text" : "Generating thumbnail."
+  "image_placeholder_text" : "Generating thumbnail.",
+  "NewEditorRibbonContent": "New Editor"
 }

--- a/src/i18n/automation-dicc-es.js
+++ b/src/i18n/automation-dicc-es.js
@@ -1636,5 +1636,6 @@ export const automation_es_translations = {
       "maxlength" : "¡Ouch! Has alcanzado la longitud máxima permitida.",
       "duplicated" : "¡Ouch! Ese nombre ya existe."
   },
-  "image_placeholder_text" : "Generando miniatura."
+  "image_placeholder_text" : "Generando miniatura.",
+  "NewEditorRibbonContent": "Nuevo Editor"
 }

--- a/src/partials/templates/dp-templates.html
+++ b/src/partials/templates/dp-templates.html
@@ -51,7 +51,7 @@
 				<div class="item" ng-repeat="template in templates">
 					<div ng-if="template.EditorType === EMAIL_EDITOR_TYPE.UNLAYER"
 						class="dp-ribbon dp-ribbon-top-left dp-ribbon-violet">
-						<span>Editor Beta</span>
+						<span>{{ 'NewEditorRibbonContent' | translate }}</span>
 					</div>
 					<div class="img-container">
 						<img ng-src="{{ getNoCacheUrl(template.TemplatePreviewUrl) }}" poll="true" show-eye="true"


### PR DESCRIPTION
Set new content for campaign template

![automation new editor ribbon en](https://github.com/FromDoppler/doppler-automation-editor/assets/83654756/e163fbfd-b17a-4128-b87c-65e5998a03d8)

![automation new editor ribbon es](https://github.com/FromDoppler/doppler-automation-editor/assets/83654756/3b286cee-268b-495d-bcbd-ab449b15ce9a)

Fixes: [DOP-1417](https://makingsense.atlassian.net/browse/DOP-1417)

[DOP-1417]: https://makingsense.atlassian.net/browse/DOP-1417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ