### PR TITLE
DOP-1425 - fix visual issue

### DIFF
--- a/src/css/doppler-common/modules/_buttons.scss
+++ b/src/css/doppler-common/modules/_buttons.scss
@@ -138,6 +138,10 @@ button {
   button.button--error {
     color: $color-white;
   }
+
+  button.button-outline--primary {
+    border: solid 1px;
+  }
 }
 
 ///Spinner button

--- a/src/partials/automation/editor/directives/footer/dp-editor-footer.html
+++ b/src/partials/automation/editor/directives/footer/dp-editor-footer.html
@@ -1,6 +1,6 @@
 <div class="item dp-library" ng-if="listSelectionState === LIST_SELECTION_STATE.NONE && !showTinyEditor">
-  <button class="button button--small button-outline--primary" ng-click="saveAndRedirect('/Automation/Automation/AutomationApp/');">{{ 'automation_editor.buttons.exit' | translate }}</button>
-  <div class="right">
+  <button class="dp-button button--small button-outline--primary" ng-click="saveAndRedirect('/Automation/Automation/AutomationApp/');">{{ 'automation_editor.buttons.exit' | translate }}</button>
+  <div class="right display-flex">
     <span ng-show="rootComponent.state !== AUTOMATION_STATE.ACTIVE && rootComponent.state !== AUTOMATION_STATE.PAUSED && isFlowComplete() !== AUTOMATION_COMPLETED_STATE.COMPLETED || hasNotSmsCredits()" class="tip-help"
           ng-class="{'warning': isFlowComplete() === AUTOMATION_COMPLETED_STATE.COMPLETE_WITH_WARNINGS && rootComponent.state !== AUTOMATION_STATE.ACTIVE, 'error': hasErrors() }">
           <span ng-bind-html="getAutomationTipLabel()"></span>


### PR DESCRIPTION
fix: 

- set dp-button to the exit button
- set display flex to the right button content

![image](https://github.com/FromDoppler/doppler-automation-editor/assets/83654756/9846fca1-3c39-455e-8e8c-5cdd7f128df3)

issue:

exit button hide
![image](https://github.com/FromDoppler/doppler-automation-editor/assets/83654756/309ea29c-a494-413c-843f-1527b072056a)

visual issue for restart button on loading state
![image](https://github.com/FromDoppler/doppler-automation-editor/assets/83654756/fbd1bdb3-ce5d-464d-80d4-1f6d0eb3c12e)
