### PR TITLE
DOP-1461 - Unify social share icon source

### DIFF
--- a/src/css/app/templates/automation/_editor-panel.scss
+++ b/src/css/app/templates/automation/_editor-panel.scss
@@ -917,7 +917,7 @@
       }
       &.dp-icon-share-twitter{
         background-size: contain;
-        background-image: url(https://cdn.fromdoppler.com/unlayer-editor/assets/color_square_twitter.png);
+        background-image: url(https://cdn.fromdoppler.com/unlayer-editor/assets/color_square_twitter_x.png);
       }
       &.dp-icon-share-whatsapp{
         background-size: contain;

--- a/src/css/app/templates/automation/_editor-panel.scss
+++ b/src/css/app/templates/automation/_editor-panel.scss
@@ -894,8 +894,35 @@
       }
     }
     span {
+      display: flex;
+      width: 30px;
+      height: 30px;
       font-size: $font-size--big;
       border: 1px solid $color-white;
+      &.dp-icon-share-facebook{
+        background-size: contain;
+        background-image: url(https://cdn.fromdoppler.com/unlayer-editor/assets/color_square_facebook.png);
+      }
+      &.dp-icon-share-googlemas{
+        background-size: contain;
+        background-image: url(https://cdn.fromdoppler.com/unlayer-editor/assets/color_square_google.png);
+      }
+      &.dp-icon-share-linkedin{
+        background-size: contain;
+        background-image: url(https://cdn.fromdoppler.com/unlayer-editor/assets/color_square_linkedin.png);
+      }
+      &.dp-icon-share-pinterest{
+        background-size: contain;
+        background-image: url(https://cdn.fromdoppler.com/unlayer-editor/assets/color_square_pinterest.png);
+      }
+      &.dp-icon-share-twitter{
+        background-size: contain;
+        background-image: url(https://cdn.fromdoppler.com/unlayer-editor/assets/color_square_twitter.png);
+      }
+      &.dp-icon-share-whatsapp{
+        background-size: contain;
+        background-image: url(https://cdn.fromdoppler.com/unlayer-editor/assets/color_square_whatsapp.png);
+      }
       &.active {
         box-shadow: 0 0 0 2px $color-primary;
       }
@@ -1018,24 +1045,6 @@
         max-width: 265px;
       }
     }
-  }
-  .icon-share-facebook {
-    color: #3B589C;
-  }
-  .icon-share-googlemas {
-    color: #D95132;
-  }
-  .icon-share-linkedin {
-    color: #097BBA;
-  }
-  .icon-share-pinterest {
-    color: #CA3837;
-  }
-  .icon-share-twitter {
-    color: #26B7EC;
-  }
-  .icon-share-whatsapp {
-    color: #25D366;
   }
 
   .dp-editor-panel-condition {

--- a/src/partials/automation/editor/directives/panel/dp-editor-panel-campaign.html
+++ b/src/partials/automation/editor/directives/panel/dp-editor-panel-campaign.html
@@ -213,7 +213,7 @@
         	<ul>
         	  <li ng-repeat="share in selectedComponent.socialShares">
     			  <a ng-click="canEdit() && (share.selected = share.selected ? false : true)">
-    			  <span class="icon-share-{{share.name}}" ng-class="{'active': share.selected}"></span></a>
+    			  <span class="dp-icon-share-{{share.name}}" ng-class="{'active': share.selected}"></span></a>
         	  </li>
         	</ul>
         </div>


### PR DESCRIPTION
Fix: replace icon font with an image on each social share icon and start to use a unique icon image in this case using unlayer assets

Fixes: [DOP-1484](https://makingsense.atlassian.net/browse/DOP-1484)


![image](https://github.com/FromDoppler/doppler-automation-editor/assets/83654756/fac926a8-0fd9-46fd-aca8-1494d0b3a423)

![image](https://github.com/FromDoppler/doppler-automation-editor/assets/83654756/e1816615-03d4-4529-a6a4-0088d197944d)


[DOP-1484]: https://makingsense.atlassian.net/browse/DOP-1484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ