### PR TITLE
fix: verify template existence before to concatenate

### DIFF
--- a/src/directives/automation/editor/dpEditorTemplate.js
+++ b/src/directives/automation/editor/dpEditorTemplate.js
@@ -40,10 +40,13 @@
         TEMPLATES.SMS,
       ];
 
-      function sortTemplateCards(templatesCardsUnsorted){
+      function sortTemplateCards(templatesCardsUnsorted) {
         return templateCardOrder.reduce((templates, templateId) => {
-          return templates.concat(templatesCardsUnsorted.find(({IdAutomationTemplate}) => IdAutomationTemplate === templateId))
-        }, [])
+          const matchingTemplate = templatesCardsUnsorted.find(({ IdAutomationTemplate }) => IdAutomationTemplate === templateId);
+      
+          // Verify template existence before to concatenate
+          return matchingTemplate ? templates.concat(matchingTemplate) : templates;
+        }, []);
       }
 
       taskService.getAutomationTemplateList()


### PR DESCRIPTION
The previous code concatenates "undefined" items in the array.

****BEFORE** (for example, the abandoned cart template is defined in the [templateCardOrder](https://github.com/FromDoppler/doppler-automation-editor/blob/main/src/directives/automation/editor/dpEditorTemplate.js#L34), but it was not in the DB):
![image](https://github.com/FromDoppler/doppler-automation-editor/assets/1985175/8e9bd84d-08e6-43d3-9d1a-77fa6ef9d0af)

****AFTER**:
![image](https://github.com/FromDoppler/doppler-automation-editor/assets/1985175/63fafda2-b81c-4374-9e89-75013eff6b02)
