### PR TITLE
refactor: move "all categories" to the first position

### DIFF
--- a/src/directives/dp-templates.js
+++ b/src/directives/dp-templates.js
@@ -66,7 +66,7 @@
       var pageStart = 0;
       var urlRandomTimeParam = new Date().getTime();
       var isLoadingPreview = false;
-      var defaultCategorySelected = 1;
+      var defaultCategorySelected = 0;
 
       var redirectToEditorCampaign = function (idCampaign, editorType) {
         window.location.href = templatesService.getEditorCampaignUrl(idCampaign, editorType);
@@ -157,7 +157,7 @@
             if ($scope.allTemplates) {
               $scope.categories.push({ IdTemplateCategory: -2, Name: $translate.instant('templates_title')});
             }
-            $scope.categories.push(allCategories);
+            $scope.categories.unshift(allCategories);
             $scope.categorySelected = { IdTemplateCategory: $scope.categories[0].IdTemplateCategory };
             if ($scope.categoryFilter){
               var category = _.find(result, function(cat){


### PR DESCRIPTION
Locate the "All Categories" option in the first position when selecting a template in the Automation Editor.

![chrome_Zi4RQI8s23](https://github.com/FromDoppler/doppler-automation-editor/assets/1985175/3e02724d-65e2-4d54-99aa-f50b21de8168)