### PR TITLE
DOP-1527 - Hide and reset verificationTime

### DIFF
--- a/src/directives/automation/editor/panel/initialConditions/dpEditorPanelSiteBehaviorCondition.js
+++ b/src/directives/automation/editor/panel/initialConditions/dpEditorPanelSiteBehaviorCondition.js
@@ -239,7 +239,16 @@
       };
 
       scope.isEnabledVerificationTime = function() {
-        return scope.selectedComponent.domains.length > 1 || scope.selectedComponent.domains[0].visitedTimes > 1;
+        const visitedTimesMoreThanOne = scope.selectedComponent.domains.some(
+          (domain) => domain.visitedTimes > 1,
+        );
+        const result =
+          (scope.selectedComponent.operator === CONDITION_OPERATOR.AND && scope.selectedComponent.domains.length > 1) ||
+          visitedTimesMoreThanOne;
+        scope.selectedComponent.verificationTime = result
+          ? scope.selectedComponent.verificationTime
+          : 0;
+        return result;
       };
 
       scope.toggleConfirmation = function(value) {


### PR DESCRIPTION
Add rules to hide and reset verification time

Rules

Show verification time:
- CONDITION_OPERATOR = AND also  two or more domain to verify
- visited some domain more than one

https://github.com/FromDoppler/doppler-automation-editor/assets/83654756/40e6128e-dd47-48b9-a6c7-e0c149acf27b



