### PR TITLE
DOP-1607 - fix sms panel visual issue

### DIFF
--- a/src/css/app/templates/automation/_editor-panel.scss
+++ b/src/css/app/templates/automation/_editor-panel.scss
@@ -1449,8 +1449,4 @@ input[type="text"].padding-r-buttons-place {
   }
 }
 
-.dp-sms-message-warning .dp-wrap-message .dp-content-message p {
-  line-height: 10px;
-}
-
 /* END: overwritten "UI library" section */


### PR DESCRIPTION
Fix: Repair line height on warning message at SMS panel 


![image](https://github.com/user-attachments/assets/b9daeb83-4969-49fc-b9c3-ca2bbde5d908)

Issue:

![image](https://github.com/user-attachments/assets/4f82f7c6-594b-4ff2-8e0a-d20630cb8186)
