### PR TITLE
DOP-1649 - Multimedia template wsp file upload fix

### DIFF
--- a/src/directives/automation/editor/panel/dpEditorPanelWhatsapp.js
+++ b/src/directives/automation/editor/panel/dpEditorPanelWhatsapp.js
@@ -117,22 +117,28 @@
       
       var inputRef = null;
       var iframeRef = null;
+      let inputUploadFile = null;
       var interval;
+      let initIframeInterval;
+      let initInputFileInterval;
 
-      function applyIntlInput() {
+      function initIframe() {
         iframeRef = document.getElementById('whatsapp_template_iframe');
         if (iframeRef !== null && scope.selectedComponent.template) { 
           iframeRef.src = scope.selectedComponent.template.publicPreviewUrl || "";
+          window.clearInterval(initIframeInterval);
         }
+      }
 
-        if(scope.hasTemplateSelected()){
-          scope.multimediaType = multimediaConstraint[scope.selectedComponent.template.headerType || 'TEXT'];
+      function initInputFile() {
+        inputUploadFile = document.getElementById('wspfileInput');
+        if (inputUploadFile !== null) {
+          inputUploadFile.addEventListener('change', uploadFileSelect, false);
+          window.clearInterval(initInputFileInterval);
         }
-        const fileInput = document.getElementById('wspfileInput');
-        if (fileInput !== null) {
-          fileInput.addEventListener('change', uploadFileSelect, false); 
-        }
+      }
 
+      function intInputTel() {
         inputRef = document.getElementById('phone_whatsapp');
         if (inputRef !== null) {
           iti = window.intlTelInput(inputRef, {
@@ -152,7 +158,15 @@
           });
         }
       }
-      interval = window.setInterval(applyIntlInput, 50);
+
+      if(scope.selectedComponent != null) {
+        interval = window.setInterval(intInputTel, 50);
+        initIframeInterval = window.setInterval(initIframe, 50);
+        initInputFileInterval = window.setInterval(initInputFile, 50);
+      }
+      if(scope.selectedComponent.template && scope.selectedComponent.template.id > 0) {
+        scope.multimediaType = multimediaConstraint[scope.selectedComponent.template.headerType || 'TEXT'];
+      }
 
       scope.changePhoneNumber = changePhoneNumber;
 

--- a/src/directives/automation/editor/panel/dpEditorPanelWhatsapp.js
+++ b/src/directives/automation/editor/panel/dpEditorPanelWhatsapp.js
@@ -330,6 +330,7 @@
         e.preventDefault();
         scope.statusUploader = 'pending';
         const file= e.target.files[0];
+        inputUploadFile.value = '';
         if (file) {
           const maxSize = scope.multimediaType.maxSise;
           if(file.size > maxSize * 1024 * 1024) {

--- a/src/directives/automation/editor/panel/dpEditorPanelWhatsapp.js
+++ b/src/directives/automation/editor/panel/dpEditorPanelWhatsapp.js
@@ -170,7 +170,7 @@
       scope.changePhoneNumber = changePhoneNumber;
 
       scope.openSelectFileModal = ()=> {
-        document.getElementById('wspfileInput').click();
+        inputUploadFile.click();
       };
 
       scope.test = function() {

--- a/src/directives/automation/editor/panel/dpEditorPanelWhatsapp.js
+++ b/src/directives/automation/editor/panel/dpEditorPanelWhatsapp.js
@@ -144,8 +144,8 @@
           iti = window.intlTelInput(inputRef, {
             placeholderNumberType: 'MOBILE',
             validationNumberType: 'MOBILE',
-            nationalMode: false,
-            separateDialCode: true,
+            nationalMode: true,
+            separateDialCode: false,
             autoPlaceholder: 'aggressive',
             preferredCountries: ['ar', 'mx', 'co', 'es', 'ec', 'cl', 'pe', 'us'],
             initialCountry: 'ar'

--- a/src/directives/automation/editor/panel/dpEditorPanelWhatsapp.js
+++ b/src/directives/automation/editor/panel/dpEditorPanelWhatsapp.js
@@ -151,7 +151,6 @@
             initialCountry: 'ar'
           });
           window.clearInterval(interval);
-            changePhoneNumber(whatsappForm);
           evaluateName();
           inputRef.addEventListener('countrychange', function() {
             changePhoneNumber(whatsappForm);

--- a/src/partials/automation/editor/directives/panel/dp-editor-panel-whatsapp.html
+++ b/src/partials/automation/editor/directives/panel/dp-editor-panel-whatsapp.html
@@ -91,7 +91,7 @@
     </div>
   </div>
 
-  <iframe class="whatsapp-content" id="whatsapp_template_iframe"></iframe>
+  <iframe class="whatsapp-content" id="whatsapp_template_iframe" ng-show ="hasTemplateSelected()" ></iframe>
 
   <div ng-if="hasTemplateSelected() && headerVariables.length > 0 && (selectedComponent.template.headerType == 'TEXT' || selectedComponent.template.headerType == undefined)">
     <p class="title" >

--- a/src/partials/automation/editor/directives/panel/dp-editor-panel-whatsapp.html
+++ b/src/partials/automation/editor/directives/panel/dp-editor-panel-whatsapp.html
@@ -157,10 +157,10 @@
     </div>
   </div>
 
-  <div class="input--group  dp-library">
+  <div class="input--group">
     <label class="label label--panel">{{ 'automation_editor.sidebar.whatsapp.whatsapp_test' | translate }}</label>
     <span class="span--sms">{{ 'automation_editor.sidebar.whatsapp.whatsapp_test_desc' | translate }}</span>
-    <div class="display-flex">
+    <div class="display-flex dp-library">
       <input id="phone_whatsapp" type="tel" class="input--text"
         ng-model="selectedComponent.whatsappPhoneNumberTest"
         ng-required="whatsappForm.whatsappPhoneNumberTest.$dirty || selectedComponent.touched"
@@ -187,8 +187,8 @@
       <div ng-message="required" class="error">{{ 'validation_messages.required' | translate }}</div>
       <div ng-show="isWhatsappPhoneNumberTestInvalidByChangeCountry" class="error">{{ 'validation_messages.phone_pattern' | translate }}</div>
     </div>
-  
-    <div class="dp-temporal-message margin-t-15" ng-show="showWhatsappSendResultMessage">
+
+    <div class="dp-temporal-message margin-t-15 dp-library" ng-show="showWhatsappSendResultMessage">
       <div class="dp-wrap-message" ng-class="sendWhatsappMessageResultClass">
         <span class="dp-message-icon"></span>
         <div class="dp-content-message dp-content-full" ng-bind-html="sendWhatsappResultMessageText"></div>

--- a/src/partials/automation/editor/directives/panel/dp-editor-panel-whatsapp.html
+++ b/src/partials/automation/editor/directives/panel/dp-editor-panel-whatsapp.html
@@ -123,12 +123,6 @@
           ng-disabled="isReadOnly();">
           {{ 'automation_editor.sidebar.whatsapp.file_uploader_button' | translate }}
         </button>
-        <input hidden 
-          type="file" 
-          id="wspfileInput" 
-          accept="{{multimediaType.acceptedFileTypes}}"
-          ng-disabled="isReadOnly();"
-        >
         <div class="dp-temporal-message margin-t-15" ng-show="showWhatsappUploadFileResultMessage">
           <div class="dp-wrap-message dp-wrap-warning">
             <span class="dp-message-icon"></span>
@@ -137,6 +131,12 @@
         </div>
       </div>
   </div>
+  <input hidden 
+    type="file" 
+    id="wspfileInput" 
+    accept="{{multimediaType.acceptedFileTypes}}"
+    ng-disabled="isReadOnly();"
+  >
 
   <div ng-if="hasTemplateSelected() && bodyVariables.length > 0">
     <p class="title" >


### PR DESCRIPTION
Fixes: 

1) split init logic for:

-  input file (upload file for multimedia whatsapp)
-  iframe (template preview)
-  input tel (mobile number for wsp send test)

2) update input tel appearance

![image](https://github.com/user-attachments/assets/002e9e1e-9df9-4b61-953d-7e02bf30b2d2)
by 
![image](https://github.com/user-attachments/assets/91022859-9e60-40e1-8d9f-849658314aee)

3) hide preview iframe when it is not template selected

![image](https://github.com/user-attachments/assets/515b2e40-5b1f-45f2-99de-1864e26ade67)

![image](https://github.com/user-attachments/assets/857c41d2-06fd-457e-862c-7a61e0314303)
