### PR TITLE
fix: replace help links for blocked lists

### DIFF
--- a/src/i18n/automation-dicc-en.js
+++ b/src/i18n/automation-dicc-en.js
@@ -488,7 +488,7 @@ export const automation_en_translations = {
     "blocked_list": {
       "tooltip_tag": "BLOCKED LIST",
       "link_text": "Learn more.",
-      "help_link": "https://help.fromdoppler.com/en/blocked-lists",
+      "help_link": "https://help.fromdoppler.com/en/how-to-debug-a-contact-list-in-doppler/?utm_source=direct",
       "tooltip_text": "There’re Subscribers that affect the quality of your List."
     },
     "lists_grid": {
@@ -513,10 +513,10 @@ export const automation_en_translations = {
       "all_contacts": "Send to all my contacts",
       "blocked_list": "There’re Subscribers that affect the quality of your List. Learn more.",
       "blocked_list_link": "Learn more.",
-      "blocked_list_href": "https://help.fromdoppler.com/en/blocked-lists",
+      "blocked_list_href": "https://help.fromdoppler.com/en/how-to-debug-a-contact-list-in-doppler/?utm_source=direct",
       "blocked_list_text": "BLOCKED LIST",
       "blocked_segment": "There’re Subscribers that affect the quality of your Segment.",
-      "blocked_segment_href": "https://help.fromdoppler.com/en/blocked-lists#blocked-segments",
+      "blocked_segment_href": "https://help.fromdoppler.com/en/how-to-debug-a-contact-list-in-doppler/?utm_source=direct",
       "blocked_segment_text": "BLOCKED SEGMENT"
     },
     "tiny_editor": {
@@ -1236,7 +1236,7 @@ export const automation_en_translations = {
   },
   "modal_blocked_lists": {
     "title": "Ouch! This Automation has blocked<br> Lists and/or blocked Segments",
-    "description": "To start it, we suggest to <b>clean your Lists</b> and delete Subscribers that affect its quality. You can also <b>revert the last Subscribers' import</b> you have made in a blocked List. Any doubt? Take a look at our <a class='link--default' href='https://help.fromdoppler.com/en/blocked-lists' target='_blank'>HELP</a>.",
+    "description": "To start it, we suggest to <b>clean your Lists</b> and delete Subscribers that affect its quality. You can also <b>revert the last Subscribers' import</b> you have made in a blocked List. Any doubt? Take a look at our <a class='link--default' href='https://help.fromdoppler.com/en/how-to-debug-a-contact-list-in-doppler/?utm_source=direct' target='_blank'>HELP</a>.",
     "button_cancel": "Go later",
     "button_action": "View Lists"
   },

--- a/src/i18n/automation-dicc-es.js
+++ b/src/i18n/automation-dicc-es.js
@@ -489,7 +489,7 @@ export const automation_es_translations = {
 		"blocked_list": {
 		"tooltip_tag": "LISTA BLOQUEADA",
 		"link_text": "Entérate más.",
-		"help_link": "https://help.fromdoppler.com/en/blocked-lists",
+		"help_link": "https://help.fromdoppler.com/en/como-depurar-una-lista-de-contactos-en-doppler/?utm_source=direct",
 		"tooltip_text": "Hay Suscriptores que afectan la calidad de tu Lista."
 	},
 	"lists_grid": {
@@ -514,10 +514,10 @@ export const automation_es_translations = {
     "all_contacts": "Enviar a todos mis contactos",
     "blocked_list": "Hay Suscriptores que afectan la calidad de tu Lista. Entérate más.",
     "blocked_list_link": "Entérate más.",
-    "blocked_list_href":  "https://help.fromdoppler.com/es/listas-bloqueadas",
+    "blocked_list_href":  "https://help.fromdoppler.com/es/como-depurar-una-lista-de-contactos-en-doppler/?utm_source=direct",
     "blocked_list_text": "LISTA BLOQUEADA",
     "blocked_segment": "Hay Suscriptores que afectan la calidad de tu Segmento.",
-    "blocked_segment_href": "https://help.fromdoppler.com/es/listas-bloqueadas#segmentos-bloqueados",
+    "blocked_segment_href": "https://help.fromdoppler.com/es/como-depurar-una-lista-de-contactos-en-doppler/?utm_source=direct",
     "blocked_segment_text": "SEGMENTO BLOQUEADO" 
 	},
 	"tiny_editor": {
@@ -1236,7 +1236,7 @@ export const automation_es_translations = {
   },
   "modal_blocked_lists": {
     "title": "¡Ouch! Este Automation contiene Listas<br> y/o Segmentos bloqueados",
-    "description": "Para poder iniciarlo, te sugerimos <b>limpiar tus Listas</b> y eliminar a los Suscriptores que afectan su calidad. También puedes <b>revertir la última importación de Suscriptores</b> que hayas realizado en una Lista bloqueada. ¿Tienes dudas? Revisa nuestro <a class='link--default' href='https://help.fromdoppler.com/es/listas-bloqueadas' target='_blank'>HELP</a>.",
+    "description": "Para poder iniciarlo, te sugerimos <b>limpiar tus Listas</b> y eliminar a los Suscriptores que afectan su calidad. También puedes <b>revertir la última importación de Suscriptores</b> que hayas realizado en una Lista bloqueada. ¿Tienes dudas? Revisa nuestro <a class='link--default' href='https://help.fromdoppler.com/es/como-depurar-una-lista-de-contactos-en-doppler/?utm_source=direct' target='_blank'>HELP</a>.",
     "button_cancel": "Ir más tarde",
     "button_action": "Ver Listas"
   },


### PR DESCRIPTION
Replace help links for blocked lists. 
Replace:
- https://help.fromdoppler.com/es/listas-bloqueadas
- https://help.fromdoppler.com/en/blocked-lists

By:
- https://help.fromdoppler.com/es/como-depurar-una-lista-de-contactos-en-doppler/?utm_source=direct (**spanish**)
- https://help.fromdoppler.com/en/how-to-debug-a-contact-list-in-doppler/?utm_source=direct (**english**)