### PR TITLE
fix: hardcoded siteTracking as true

### DIFF
--- a/src/services/automation/editor/automation.js
+++ b/src/services/automation/editor/automation.js
@@ -780,7 +780,9 @@
 
       settingsService.getSettings().then(function(response) {
         domains = response.domains;
-        siteTracking = response.siteTrackingActive;
+        // TODO: remove the 'siteTracking' flag and analyze the places where it is being used.
+        // siteTracking = response.siteTrackingActive;
+        siteTracking = true;
         $rootScope.thirdPartyAppsConnected = response.thirdPartyAppsListConnected;
         thirdPartyAppsConnected = response.thirdPartyAppsListConnected;
 


### PR DESCRIPTION
Fix: hardcoded siteTracking as true ([related change](https://github.com/MakingSense/Doppler/pull/11052/files#diff-be7b6f25c8f4f4ffb6ac6810eb05990e87c0710c96d0abf8646853998151429dL387))

**TODO:** remove the 'siteTracking' flag and analyze the places where it is being used.

**Antes:**

https://github.com/user-attachments/assets/e240a0b0-75d5-4a46-ac18-9c677de3114e


**Despues:**

https://github.com/user-attachments/assets/d217f815-f503-49ed-a52b-7fe801235b5d





