### PR TITLE
No ticket fix sms message counter and sms content valid

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -36,6 +36,7 @@ var Regex = {
   URL_WITH_SUBFOLDERS: /^((http(s)?(:\/\/))?(www\.)?(([a-zA-Z0-9\-_]+\.)+)([a-zA-Z]{2,16})(\/+(([a-zA-Z0-9\-_])+))*(\/\*?)?)$/i, // eslint-disable-line
   REGEX_GSM_7BIT_CHARS: "@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞÆæßÉ !\"#¤%&'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà", // eslint-disable-line
   REGEX_GSM_7BIT_EXTENDED_CHARS: "^{}\\[~]|€",
+  REGEX_SMS: /^[\u000A\u000D\u0020-\u007A\u00A1\u00C0-\u00FF€^{}\[\]~|\\]*$/, // eslint-disable-line
   URL_WITH_SUBFOLDERS_HTTPS_ONLY: /^(https:\/\/(www\.)?(([a-zA-Z0-9\-_]+\.)+)([a-zA-Z]{2,23})(\/+(([a-zA-Z0-9\-_.?=&#])+))*(\/\*?)?)$/i, // eslint-disable-line
   STRICT_START_HTTPS: /^(https:\/\/)(\S+)?$/i,
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -34,8 +34,8 @@ var Regex = {
   DOMAIN: /^((?!www\.)(([a-zA-Z0-9\-_ñÑ]+\.)+)([a-zA-Z]{2,16}))$/i, // eslint-disable-line
   DOMAIN_HTTP: /^((http(s)?(:\/\/))?(www\.)?(([a-zA-Z0-9\-_ñÑ]+\.)+)([a-zA-Z]{2,16}))$/i, // eslint-disable-line
   URL_WITH_SUBFOLDERS: /^((http(s)?(:\/\/))?(www\.)?(([a-zA-Z0-9\-_]+\.)+)([a-zA-Z]{2,16})(\/+(([a-zA-Z0-9\-_])+))*(\/\*?)?)$/i, // eslint-disable-line
-  REGEX_SMS_STRING: "@£$¥èéùìòÇ`Øø`ÅåΔ_ΦΓΛΩΠΨΣΘΞ`ÆæßÉ !\"#¤%&'()*=,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ`¿abcdefghijklmnopqrstuvwxyzäöñüà", // eslint-disable-line
-  REGEX_SMS_GSM_EXTENDED_STRING: "````````````````````^```````````````````{}`````\\````````````[~]`|````````````````````````````````````€``````````````````````````", // eslint-disable-line
+  REGEX_GSM_7BIT_CHARS: "@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞÆæßÉ !\"#¤%&'()*+,-./0123456789:;<=>?¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§¿abcdefghijklmnopqrstuvwxyzäöñüà", // eslint-disable-line
+  REGEX_GSM_7BIT_EXTENDED_CHARS: "^{}\\[~]|€",
   URL_WITH_SUBFOLDERS_HTTPS_ONLY: /^(https:\/\/(www\.)?(([a-zA-Z0-9\-_]+\.)+)([a-zA-Z]{2,23})(\/+(([a-zA-Z0-9\-_.?=&#])+))*(\/\*?)?)$/i, // eslint-disable-line
   STRICT_START_HTTPS: /^(https:\/\/)(\S+)?$/i,
 }

--- a/src/directives/automation/editor/panel/dpEditorPanelSms.js
+++ b/src/directives/automation/editor/panel/dpEditorPanelSms.js
@@ -31,7 +31,7 @@
       scope.phoneOptions = [];
       scope.charactersCount = scope.selectedComponent.smsText ? scope.selectedComponent.smsText.length : 0;
       scope.smsPartsCount = scope.selectedComponent.smsText ? getSmsPartsCount(scope.selectedComponent.smsText) : 0;
-      scope.REGEX_SMS = REGEX.REGEX_SMS;
+      scope.REGEX_SMS = new RegExp(REGEX.REGEX_SMS);
       scope.isLoaded = false;
       scope.getReadOnlyLabel = automation.getReadOnlyLabel;
       scope.hasColombiaCodeSmsActive = settingsService.getLoadedData().hasColombiaCountryCodeSmsActive;

--- a/src/directives/automation/editor/panel/dpEditorPanelSms.js
+++ b/src/directives/automation/editor/panel/dpEditorPanelSms.js
@@ -90,15 +90,31 @@
       };
 
       function getSmsPartsCount(smsText) {
-        if (smsText.length >= 70) {
-          for (var i = 0; i < smsText.length; i++) {
-            if (REGEX.REGEX_SMS_STRING.indexOf(smsText.charAt(i)) === -1 &&
-              REGEX.REGEX_SMS_GSM_EXTENDED_STRING.indexOf(smsText.charAt(i)) === -1) {
-              return Math.ceil(smsText.length / 67);
-            }
+        let isUnicode = false;
+        let length = 0;
+
+        for (let char of smsText) {
+          if (REGEX.REGEX_GSM_7BIT_CHARS.includes(char)) {
+            length += 1;
+          } else if (REGEX.REGEX_GSM_7BIT_EXTENDED_CHARS.includes(char)) {
+            length += 2; // Extended characters use escape sequence
+          } else {
+            isUnicode = true;
+            break;
           }
         }
-        return 1;
+
+        if (isUnicode) {
+          // UCS-2 encoding: 70 chars per SMS, 67 for multipart
+          return smsText.length <= 70
+            ? 1
+            : Math.ceil(smsText.length / 67);
+        } else {
+          // GSM-7 encoding: 160 per SMS, 153 for multipart
+          return length <= 160
+            ? 1
+            : Math.ceil(length / 153);
+        }
       }
 
       function evaluateName() {


### PR DESCRIPTION
Fix:

Improve the function to count the message count by content
Add a regex to validate sms content 

<img width="397" height="135" alt="image" src="https://github.com/user-attachments/assets/d9c59a00-2e91-48c3-b003-2bfdd6d9f473" />

with special characters
<img width="382" height="133" alt="image" src="https://github.com/user-attachments/assets/90d93d38-9a19-4550-bfa4-d55df53478c1" />

with invalid characters
<img width="402" height="364" alt="image" src="https://github.com/user-attachments/assets/e7145b1a-853f-404b-82ef-9de85b6db867" />

