### PR TITLE
No Ticket - block start  when a step without action

### DIFF
--- a/src/css/doppler-common/modules/_buttons.scss
+++ b/src/css/doppler-common/modules/_buttons.scss
@@ -85,13 +85,6 @@ button {
   color: $color-base;
 }
 
-.button--warning {
-  background: $color-primary;
-  &:hover {
-    background: $color-darkyellow;
-  }
-}
-
 [class*=button-outline-] {
   background: transparent;
   border-style: solid;

--- a/src/directives/automation/editor/footer/dpEditorFooter.js
+++ b/src/directives/automation/editor/footer/dpEditorFooter.js
@@ -162,9 +162,7 @@
         	return;
         }
         if (scope.rootComponent.state !== AUTOMATION_STATE.ACTIVE) {
-          if (isFlowComplete === AUTOMATION_COMPLETED_STATE.COMPLETE_WITH_WARNINGS) {
-            label = $translate.instant('automation_editor.buttons.start_campaign_warning');
-          } else if (scope.rootComponent.state === AUTOMATION_STATE.PAUSED) {
+          if (scope.rootComponent.state === AUTOMATION_STATE.PAUSED) {
             label = $translate.instant('automation_editor.buttons.restart_campaign');
           } else if (scope.rootComponent.state === AUTOMATION_STATE.STOPPED) {
             label = $translate.instant('automation_editor.buttons.reactivate_campaign');

--- a/src/i18n/automation-dicc-en.js
+++ b/src/i18n/automation-dicc-en.js
@@ -30,7 +30,6 @@ export const automation_en_translations = {
       "confirm": "Confirm",
       "confirm_selection": "Confirm selection",
       "start_campaign": "Start Automation",
-      "start_campaign_warning": "Start Automation anyway",
       "stop_campaign": "Stop Automation",
       "skip_selection": "Skip the selection ",
       "pause_campaign": "Pause Automation",

--- a/src/i18n/automation-dicc-es.js
+++ b/src/i18n/automation-dicc-es.js
@@ -30,7 +30,6 @@ export const automation_es_translations = {
 		"confirm": "Confirmar",
 		"confirm_selection": "Confirmar la selección",
 		"start_campaign": "Iniciar Automation",
-		"start_campaign_warning": "Iniciar Automation de todos modos",
 		"stop_campaign": "Detener Automation",
 		"skip_selection": "Saltear la selección ",
     "pause_campaign": "Pausar Automation",

--- a/src/partials/automation/editor/directives/footer/dp-editor-footer.html
+++ b/src/partials/automation/editor/directives/footer/dp-editor-footer.html
@@ -10,8 +10,12 @@
             ng-show="rootComponent.state === AUTOMATION_STATE.ACTIVE || rootComponent.state === AUTOMATION_STATE.PAUSED"
             ng-click="stopCampaign();">{{ 'automation_editor.buttons.stop_campaign' | translate }}</button>
     <button class="dp-button button--small primary-green"
-            ng-class="{'button--warning': isFlowComplete() === AUTOMATION_COMPLETED_STATE.COMPLETE_WITH_WARNINGS, 'button--error': hasErrors(), 'button--loading': isProcessing() }"
-            ng-show="rootComponent.state !== AUTOMATION_STATE.ACTIVE" ng-disabled="isFlowComplete() === AUTOMATION_COMPLETED_STATE.INCOMPLETE || hasErrors() || hasNotSmsCredits()"
+            ng-class="{ 'button--error': hasErrors(), 'button--loading': isProcessing() }"
+            ng-show="rootComponent.state !== AUTOMATION_STATE.ACTIVE" 
+            ng-disabled="isFlowComplete() === AUTOMATION_COMPLETED_STATE.INCOMPLETE 
+                || isFlowComplete() === AUTOMATION_COMPLETED_STATE.COMPLETE_WITH_WARNINGS
+                || hasErrors() 
+                || hasNotSmsCredits()"
             ng-click="startCampaignWithDynamicCheck();">{{ getAutomationBtnLabel() }}</button>
     <button class="dp-button button--small button--error"
             ng-show="rootComponent.state === AUTOMATION_STATE.ACTIVE"


### PR DESCRIPTION
fix: replace logic from start automation with a warning by blocking start automations when it has some warning (a step without an end action)

<img width="1037" height="697" alt="image" src="https://github.com/user-attachments/assets/f98e6809-e5e7-4eae-9e46-9d3261805dec" />

