### PR TITLE
DOP-1864   - Add query param filter for domain at site behavior conditions

### DIFF
--- a/src/i18n/automation-dicc-en.js
+++ b/src/i18n/automation-dicc-en.js
@@ -129,6 +129,7 @@ export const automation_en_translations = {
             "at_least": " at least",
             "more_times": "times",
             "separator": "the URL ",
+            "with_param": "with paramater",
             "more_urls": " ...",
             "visited": " has visited ",
             "no_visited": " hasn't visit ",
@@ -156,6 +157,7 @@ export const automation_en_translations = {
               "url_has_parameters": "Ouch! The entered URL has parameters that can't be processed by the system. Try removing characters after the ?"
             },
             "placeholder": "URL",
+            "url_param_placeholder": "Filter URL parameters (optional)",
             "visited_page": "Visited the page",
             "visited_count": "time / times",
             "verification_time_title": "Define when you want we verify whether the Condition has been met",

--- a/src/i18n/automation-dicc-es.js
+++ b/src/i18n/automation-dicc-es.js
@@ -121,6 +121,7 @@ export const automation_es_translations = {
           "at_least": " al menos",
           "more_times": "veces",
           "separator": "la URL ",
+          "with_param": "con parámetro",
           "more_urls": " ...",
           "visited": " ha visitado ",
           "no_visited": " no ha visitado ",
@@ -148,6 +149,7 @@ export const automation_es_translations = {
             "url_has_parameters": "¡Ouch! La URL ingresada posee parámetros que no pueden ser procesados por el sistema. Intenta quitar los caracteres ubicados después del ?"
           },
           "placeholder": "URL",
+          "url_param_placeholder": "filtrar parametros en URL (opcional)",
           "visited_page": "Visitó la página",
           "visited_count": "vez / veces",
           "verification_time_title": "Define cuándo quieres que verifiquemos si la Condición se ha cumplido",

--- a/src/partials/automation/editor/directives/components/initialConditions/dp-editor-site-behavior-condition.html
+++ b/src/partials/automation/editor/directives/components/initialConditions/dp-editor-site-behavior-condition.html
@@ -9,7 +9,12 @@
           'automation_editor.components.initial_condition.site_behavior.canvas.no_visited' :
         'automation_editor.components.initial_condition.site_behavior.canvas.visited'
       | translate}}</span><span>{{'automation_editor.components.initial_condition.site_behavior.canvas.separator'
-        | translate}}</span><strong>{{domain.url}}</strong><span ng-if="domain.visitedTimes > 1 && domain.visitedPage">
+        | translate}}</span><strong>{{domain.url}}</strong>
+        <span ng-if="domain.urlParam && domain.urlParam.length > 1">
+          {{'automation_editor.components.initial_condition.site_behavior.canvas.with_param' | translate}}
+          <strong>{{domain.urlParam}}</strong>
+        </span>
+        <span ng-if="domain.visitedTimes > 1 && domain.visitedPage">
             {{'automation_editor.components.initial_condition.site_behavior.canvas.at_least' | translate}}
             {{domain.visitedTimes}} {{'automation_editor.components.initial_condition.site_behavior.canvas.more_times' | translate}}
             </span></span><span ng-if="index === 3">

--- a/src/partials/automation/editor/directives/panel/dp-editor-panel-condition.html
+++ b/src/partials/automation/editor/directives/panel/dp-editor-panel-condition.html
@@ -328,6 +328,12 @@
           ng-blur="onDomainBlur($event,conditional.domain)"
           ng-disabled="isReadOnly();"
           placeholder="{{'automation_editor.components.initial_condition.site_behavior.panel.placeholder' | translate}}"/>
+        <input class="input--text" type="text"
+          name="urlParam{{index}}"
+          ng-maxlength="200"
+          ng-model="conditional.domain.urlParam"
+          ng-disabled="isReadOnly();"
+          placeholder="{{'automation_editor.components.initial_condition.site_behavior.panel.url_param_placeholder' | translate}}" />
         <div class="error-messages--container" ng-if="conditional.duplicate !== DUPLICATE_STATE.FALSE && conditional.duplicate !== DUPLICATE_STATE.ORIGIN">
            <div class="error" ng-show="conditional.duplicate !== DUPLICATE_STATE.FALSE && conditional.duplicate !== DUPLICATE_STATE.ORIGIN">{{'automation_editor.components.condition.conditionals.error.duplicate_conditional' | translate}}</div>
         </div>

--- a/src/partials/automation/editor/directives/panel/dp-editor-panel-condition.html
+++ b/src/partials/automation/editor/directives/panel/dp-editor-panel-condition.html
@@ -449,7 +449,12 @@
       <!-- SITE_BEHAVIOR - COLLAPSED -->
       <div ng-if="conditional.completed && conditional.type === CONDITIONAL_TYPE.SITE_BEHAVIOR">
         {{ 'automation_editor.components.initial_condition.site_behavior.canvas.a_subscriber' | translate }} <strong> {{ conditional.domain.visitedPage ? 'automation_editor.components.initial_condition.site_behavior.canvas.visited' : 'automation_editor.components.initial_condition.site_behavior.canvas.no_visited' | translate}} </strong> {{ 'automation_editor.components.initial_condition.site_behavior.canvas.separator' | translate }}
-        <strong>{{conditional.domain.url}}</strong><span ng-if="conditional.domain.visitedPage && conditional.domain.visitedTimes > 1">
+        <strong>{{conditional.domain.url}}</strong>
+        <span ng-if="conditional.domain.urlParam &&conditional.domain.urlParam.length > 1">
+          {{'automation_editor.components.initial_condition.site_behavior.canvas.with_param' | translate}}
+          <strong>{{conditional.domain.urlParam}}</strong>
+        </span>
+        <span ng-if="conditional.domain.visitedPage && conditional.domain.visitedTimes > 1">
           {{'automation_editor.components.initial_condition.site_behavior.canvas.at_least' | translate}}
           {{conditional.domain.visitedTimes}}
           {{'automation_editor.components.initial_condition.site_behavior.canvas.more_times' | translate}}

--- a/src/partials/automation/editor/directives/panel/initialConditions/dp-editor-panel-site-behavior-condition.html
+++ b/src/partials/automation/editor/directives/panel/initialConditions/dp-editor-panel-site-behavior-condition.html
@@ -28,6 +28,12 @@
           ng-blur="onDomainBlur($event,domain)"
           ng-disabled="isReadOnly();"
           placeholder="{{'automation_editor.components.initial_condition.site_behavior.panel.placeholder' | translate}}" />
+        <input class="input--text" type="text"
+          name="urlParam{{index}}"
+          ng-maxlength="200"
+          ng-model="domain.urlParam"
+          ng-disabled="isReadOnly();"
+          placeholder="{{'automation_editor.components.initial_condition.site_behavior.panel.url_param_placeholder' | translate}}" />
         <div ng-show="showErrors" class="error-messages--container" ng-messages="siteBehaviorForm['url' + index].$error">
           <div ng-message="required"></div>
           <div ng-message="domain" class="error">


### PR DESCRIPTION
Fix: Add a new property `urlParam` to the domain object for site behavior conditions

NOTE: Pending for merge

 site behavior init condition 
<img width="1402" height="537" alt="image" src="https://github.com/user-attachments/assets/da9a9f2f-8c0a-4226-b7f4-0dbb4b1d319c" />

edit mode at condition
<img width="397" height="493" alt="image" src="https://github.com/user-attachments/assets/63119703-2409-4b94-adde-fb7296c6c680" />

view mode at condition
<img width="401" height="364" alt="image" src="https://github.com/user-attachments/assets/81ce78ae-696a-41cd-ac30-d1cefa50467e" />
