### PR TITLE
DOP-1845 - hide MS Editor public templates

### DIFF
--- a/src/i18n/automation-dicc-en.js
+++ b/src/i18n/automation-dicc-en.js
@@ -1764,6 +1764,5 @@ export const automation_en_translations = {
       "maxlength" : "Ouch! You have reached the maximum allowed length.",
       "duplicated" : "Ouch! That name already exists."
   },
-  "image_placeholder_text" : "Generating thumbnail.",
-  "NewEditorRibbonContent": "New Editor"
+  "image_placeholder_text" : "Generating thumbnail."
 }

--- a/src/i18n/automation-dicc-es.js
+++ b/src/i18n/automation-dicc-es.js
@@ -1766,6 +1766,5 @@ export const automation_es_translations = {
       "maxlength" : "¡Ouch! Has alcanzado la longitud máxima permitida.",
       "duplicated" : "¡Ouch! Ese nombre ya existe."
   },
-  "image_placeholder_text" : "Generando miniatura.",
-  "NewEditorRibbonContent": "Nuevo Editor"
+  "image_placeholder_text" : "Generando miniatura."
 }

--- a/src/partials/templates/dp-templates.html
+++ b/src/partials/templates/dp-templates.html
@@ -49,10 +49,6 @@
 			<div class="items" infinite-scroll="onScroll" infinite-scroll-element="{{ getInfiniteScrollElement() }}"
 				infinite-scroll-distance="200">
 				<div class="item" ng-repeat="template in templates">
-					<div ng-if="template.EditorType === EMAIL_EDITOR_TYPE.UNLAYER"
-						class="dp-ribbon dp-ribbon-top-left dp-ribbon-violet">
-						<span>{{ 'NewEditorRibbonContent' | translate }}</span>
-					</div>
 					<div class="img-container">
 						<img ng-src="{{ getNoCacheUrl(template.TemplatePreviewUrl) }}" poll="true" show-eye="true"
 							dp-on-error-src="../../../img/asyncPreview/container_280x280.svg" />


### PR DESCRIPTION
Fix: remove the new editor ribbon for templates

Fixes: [DOP-1845](https://makingsense.atlassian.net/browse/DOP-1845)

[DOP-1845]: https://makingsense.atlassian.net/browse/DOP-1845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ