### PR TITLE
DOP-2083 - Add custom error for dynamic content

### DIFF
--- a/src/directives/automation/editor/footer/dpEditorFooter.js
+++ b/src/directives/automation/editor/footer/dpEditorFooter.js
@@ -53,7 +53,7 @@
           || automationType === AUTOMATION_TYPE.PENDING_ORDER
           || automationType === AUTOMATION_TYPE.CONFIRMATION_ORDER) {
           automation.hasDynamicElement().then(function(result) {
-            if (result) {
+            if (result.success) {
               scope.startCampaign();
             } else {
               ModalService.showModal({
@@ -61,6 +61,7 @@
                 controller: 'ModalNoDynamicElementCtrl',
                 inputs: {
                   data: {
+                    errorCode: result.errorCode,
                     automationType: automationType
                   }
                 }

--- a/src/directives/automation/editor/panel/dpEditorPanelCondition.js
+++ b/src/directives/automation/editor/panel/dpEditorPanelCondition.js
@@ -612,7 +612,7 @@
           || automationType === AUTOMATION_TYPE.PENDING_ORDER) {
           if (scope.selectedConditional.email) {
             automation.hasDynamicElement(scope.selectedConditional.email.idEmail).then(function(result) {
-              if (!result) {
+              if (!result.success) {
                 scope.campaignBehaviorEvents = _.filter(scope.campaignBehaviorEvents, function(event) {
                   return event.value !== CONDITIONAL_EVENT.ANY_DYNAMIC_LINK_CLICKED
                     && event.value !== CONDITIONAL_EVENT.NO_DYNAMIC_LINK_CLICKED;

--- a/src/i18n/automation-dicc-en.js
+++ b/src/i18n/automation-dicc-en.js
@@ -1042,6 +1042,7 @@ export const automation_en_translations = {
       "description_visited_products": "You are about to start this Automation without showing elements of Products Visited by your users in any Email.",
       "description_pending_order": "Your Email doesn’t have the <b>Order Detail element</b>, so the information about products with pending payments won’t be shown. Any doubt? Go to <a class=\"help-text\" href=\"https://help.fromdoppler.com/en/how-to-create-pending-payment-automation\" target=\"_blank\">HELP</a>.",
       "description_confirmation_order": "Your Email doesn’t have the <b>Order Detail element</b>, so the information about products won’t be shown. Any doubt? Go to <a class=\"help-text\" href=\"https://help.fromdoppler.com/en/how-to-create-successful-payment-automation\" target=\"_blank\">HELP</a>.",
+      "description_not_available": "Please review your campaign content. Some items are not available in your store",
       "cancel": "BACK",
       "start": "START ANYWAY"
     },

--- a/src/i18n/automation-dicc-es.js
+++ b/src/i18n/automation-dicc-es.js
@@ -1041,6 +1041,7 @@ export const automation_es_translations = {
       "description_visited_products": "Estás por iniciar el Automation sin mostrar elementos de Productos Visitados por tus usuarios en ningún Email.",
       "description_pending_order": "Tu Email no posee el <b>elemento Detalle de Compra</b>, por lo que la información sobre los productos pendientes de pago no se mostrará. ¿Tienes dudas? Revisa el <a class=\"help-text\" href=\"https://help.fromdoppler.com/es/como-crear-automation-de-pago-pendiente\" target=\"_blank\">HELP</a>.",
       "description_confirmation_order": "Tu Email no posee el <b>elemento Detalle de Compra</b>, por lo que la información sobre los productos no se mostrará. ¿Tienes dudas? Revisa el <a class=\"help-text\" href=\"https://help.fromdoppler.com/es/como-crear-automation-pago-confirmado\" target=\"_blank\">HELP</a>.",
+      "description_not_available": "Por favor, revisa el contenido de tus campañas ya que existen elementos no disponibles en tu tienda",
       "cancel": "VOLVER",
       "start": "INICIAR DE TODAS FORMAS"
     },

--- a/src/partials/automation/noDynamicElementModal.html
+++ b/src/partials/automation/noDynamicElementModal.html
@@ -3,7 +3,8 @@
     <a class="icon-close modal--do-close" data-dismiss="modal"></a>
     <div class="modal__content">
       <h1>{{ 'automation_editor.no_dynamic_element_modal.title' | translate }}</h1>
-      <p ng-bind-html="'automation_editor.no_dynamic_element_modal.description_' + data.automationType | translate"></p>
+      <p ng-if="data.errorCode === 301" ng-bind-html="'automation_editor.no_dynamic_element_modal.description_' + data.automationType | translate"></p>
+      <p ng-if="data.errorCode === 302" ng-bind-html="'automation_editor.no_dynamic_element_modal.description_not_available' | translate"></p>
     </div>
     <div class="modal__action-btn">
       <button class="button button--alternative button--small" data-dismiss="modal">{{ 'automation_editor.no_dynamic_element_modal.cancel' | translate }}</button>

--- a/src/services/automation/editor/automation.js
+++ b/src/services/automation/editor/automation.js
@@ -548,7 +548,7 @@
     function hasDynamicElement(idCampaign) {
       var defer = $q.defer();
       automationDataservice.hasDynamicContent(model.id, idCampaign).then(function(result) {
-        defer.resolve((JSON.parse(result.data)));
+        defer.resolve(result.data);
       });
       return defer.promise;
     }


### PR DESCRIPTION
Descripción
Este PR adapta el flujo de validación de contenido dinámico al nuevo contrato de hasDynamicContent, que ahora devuelve un objeto con success y errorCode.

Además, se actualiza el modal para mostrar mensajes distintos según el código de error retornado por backend:

301: mantiene el mensaje de campañas sin elemento dinamico.
302: muestra un nuevo mensaje “items no disponibles en la tienda”.
Cambios realizados

Se dejó de parsear manualmente la respuesta en automation.hasDynamicElement() y se usa result.data directamente.
Se actualizaron validaciones que antes esperaban booleano para que ahora usen result.success.
Se pasa errorCode al modal desde el footer.
Se actualizó la vista del modal para renderizar contenido condicional por errorCode.

<img width="628" height="274" alt="image" src="https://github.com/user-attachments/assets/d3543f57-a451-4938-ba92-45379acad2f1" />
